### PR TITLE
RDKVREFPLT-3164: update the layer template

### DIFF
--- a/conf/template/bblayers.conf.sample
+++ b/conf/template/bblayers.conf.sample
@@ -17,15 +17,18 @@ BBLAYERS ?= " \
   ${MANIFEST_PATH_IMAGE_SUPPORT} \
   "
 
+# Generic layers
+BBLAYERS =+ "${@'${MANIFEST_PATH_RDK_IMAGES}' if os.path.isfile('${MANIFEST_PATH_RDK_IMAGES}/conf/layer.conf') else ''}"
+BBLAYERS =+ "${@'${MANIFEST_PATH_PRODUCT_LAYER}' if os.path.isfile('${MANIFEST_PATH_PRODUCT_LAYER}/conf/layer.conf') else ''}"
+BBLAYERS =+ "${@'${MANIFEST_PATH_STACK_LAYERING_SUPPORT}' if os.path.isfile('${MANIFEST_PATH_STACK_LAYERING_SUPPORT}/conf/layer.conf') else ''}"
+BBLAYERS =+ "${@'${MANIFEST_PATH_RDK_AUXILIARY}' if os.path.isfile('${MANIFEST_PATH_RDK_AUXILIARY}/conf/layer.conf') else ''}"
+
+# All required release layers
 BBLAYERS =+ "${@'${MANIFEST_PATH_COMMON_OSS_REFERENCE}' if os.path.isfile('${MANIFEST_PATH_COMMON_OSS_REFERENCE}/conf/layer.conf') else ''}"
 BBLAYERS =+ "${@'${MANIFEST_PATH_OSS_RELEASE}' if os.path.isfile('${MANIFEST_PATH_OSS_RELEASE}/conf/layer.conf') else ''}"
-
-BBLAYERS =+ "${@'${MANIFEST_PATH_RDK_IMAGES}' if os.path.isfile('${MANIFEST_PATH_RDK_IMAGES}/conf/layer.conf') else ''}"
 BBLAYERS =+ "${@'${MANIFEST_PATH_VENDOR_RELEASE}' if os.path.isfile('${MANIFEST_PATH_VENDOR_RELEASE}/conf/layer.conf') else ''}"
 BBLAYERS =+ "${@'${MANIFEST_PATH_APPLICATION_RELEASE}' if os.path.isfile('${MANIFEST_PATH_APPLICATION_RELEASE}/conf/layer.conf') else ''}"
 BBLAYERS =+ "${@'${MANIFEST_PATH_MW_RELEASE}' if os.path.isfile('${MANIFEST_PATH_MW_RELEASE}/conf/layer.conf') else ''}"
-BBLAYERS =+ "${@'${MANIFEST_PATH_FOUNDATION_RELEASE}' if os.path.isfile('${MANIFEST_PATH_FOUNDATION_RELEASE}/conf/layer.conf') else ''}"
-BBLAYERS =+ "${@'${MANIFEST_PATH_PRODUCT_LAYER}' if os.path.isfile('${MANIFEST_PATH_PRODUCT_LAYER}/conf/layer.conf') else ''}"
 
 # Config layers
 BBLAYERS =+ "${@'${MANIFEST_PATH_COMMON_CONFIG}' if os.path.isfile('${MANIFEST_PATH_COMMON_CONFIG}/conf/layer.conf') else ''}"

--- a/recipes-images/rdk-fullstack-image.bb
+++ b/recipes-images/rdk-fullstack-image.bb
@@ -2,7 +2,6 @@ SUMMARY = "RDK Full Stack image"
 
 LICENSE = "MIT"
 IMAGE_INSTALL = " \
-                 packagegroup-foundation-layer \
                  packagegroup-vendor-layer \
                  packagegroup-middleware-generic \
                  packagegroup-application-layer \


### PR DESCRIPTION
Reason For Change: Added support for new meta-layers and removed deprecated one.

Added/updated following layers:
- meta-rdk-auxiliary (develop)
- meta-stack-layering-support (v1.3.1)
- meta-image-support (v3.0.8) - to be deprecated later

Removed foundation layer and dependent package group.