### PR TITLE
RDKVREFPLT-4883: lib32-nss package error during assembler image build.

### DIFF
--- a/recipes-images/rdk-fullstack-image.bb
+++ b/recipes-images/rdk-fullstack-image.bb
@@ -1,6 +1,9 @@
 SUMMARY = "RDK Full Stack image"
 
 LICENSE = "MIT"
+
+DEPENDS += "nss-native"
+
 IMAGE_INSTALL = " \
                  packagegroup-vendor-layer \
                  packagegroup-middleware-layer \


### PR DESCRIPTION
Reason for change:
	*lib32-nss package is missing in the build
	*updated package group with nss package.
	*ref : rdkcentral/meta-image-assembler#4
Test Procedure: build image.
Risks: High.