### PR TITLE
RDKVREFPLT-4538: [AML]Rootfs process commands failed on image assembler build.

### DIFF
--- a/classes/rdkv-community-configs.bbclass
+++ b/classes/rdkv-community-configs.bbclass
@@ -20,7 +20,9 @@ dobby_generic_config_patch() {
 # Mandatory: WebPA endpoint needs to be configured in 'partners_defaults.json' by the Operator.
 ROOTFS_POSTPROCESS_COMMAND:append = " update_community_webpa_url;"
 update_community_webpa_url() {
-    bbnote "Updating WebPA URL in partners_defaults.json..."
+    bbnote "Checking if ${IMAGE_ROOTFS}/etc/partners_defaults.json exists..."
+    if [ -f "${IMAGE_ROOTFS}/etc/partners_defaults.json" ]; then
+        bbnote "partners_defaults.json found, updating WebPA URL..."
     python3 << EOF
 import json
 
@@ -34,6 +36,9 @@ data['community']['Device.X_RDK_WebPA_Server.URL'] = "http://webpa.rdkcentral.co
 with open(file_path, 'w') as file:
     json.dump(data, file, indent=4)
 EOF
+    else
+        bbnote "${IMAGE_ROOTFS}/etc/partners_defaults.json not found, skipping WebPA URL update."
+    fi
 }
 
 # Mandatory: Some of the RFC configurations for healthy runtime.
@@ -60,8 +65,18 @@ map_rdkshell_keys() {
 # Optional: To expose access of Thunder to the local network for Tests/Tools.
 ROOTFS_POSTPROCESS_COMMAND:append = " wpeframework_binding_patch;"
 wpeframework_binding_patch() {
-    bbnote "Changing Thunder 'binding' to '0.0.0.0'..."
-    sed -i "s/127.0.0.1/0.0.0.0/g" ${IMAGE_ROOTFS}/etc/WPEFramework/config.json
+    bbnote "Checking if ${IMAGE_ROOTFS}/etc/WPEFramework/config.json exists..."
+    if [ -f "${IMAGE_ROOTFS}/etc/WPEFramework/config.json" ]; then
+        sed -i "s/127.0.0.1/0.0.0.0/g" ${IMAGE_ROOTFS}/etc/WPEFramework/config.json
+
+        if grep -q "0.0.0.0" "${IMAGE_ROOTFS}/etc/WPEFramework/config.json"; then
+            bbnote "Thunder 'binding' successfully updated to '0.0.0.0'."
+        else
+            bbwarn "Thunder 'binding' update failed. Check the sed command or config file content."
+        fi
+    else
+        bbnote "${IMAGE_ROOTFS}/etc/WPEFramework/config.json not found. Skipping Thunder 'binding' patch."
+    fi
 }
 
 # Optional: SSH keys are installed by the Operator to ensure the device is accessible securely if required.


### PR DESCRIPTION
**Reason for change:** Added the file presence precondition for **update_community_webpa_url** and **wpeframework_binding_patch** these two do_rootfs process commands. 
We faced the issue on do_rootfs on Amlogic specific vendor-image.bb recipe. **partners_defaults.json** and **WPEFramework/config.json** are generated by middleware components. so, these two files are not available in soc specific recipe rootfs directory.
This same error is reproduced in core-image-minimal.bb recipe also.
**vendor-image.bb** and **core-image-minimal.bb** these two recipes are needed for final image generation for Amlogic.
**Test Procedure:** Build and verify.
**Risks:** High.
**Signed-off-by:** sundaramuneeswaran_muthuraj@comcast.com