### PR TITLE
RDKVREFPLT-4513: [AML/AML TV] Added the DolbyVision RFC default value.

### DIFF
--- a/conf/community-rfc-configs.ini
+++ b/conf/community-rfc-configs.ini
@@ -22,3 +22,4 @@ Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.Telemetry.ConfigURL=https://xconf
 Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.AccountInfo.AccountID="1234"
 Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.Telemetry.MTLS.Enable=false
 Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.AppHibernate.Enable=true
+Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.DolbyVision.Enable=true


### PR DESCRIPTION
Reason for change: Added the DolbyVision RFC default value.
Test Procedure: Build and verify the dolby vision supported content.
Risks: High.
Signed-off-by: sundaramuneeswaran_muthuraj@comcast.com