### PR TITLE
RDKVREFPLT-5668 [RDKE][AML] Non root user support for Amazon

### DIFF
--- a/conf/community-rfc-configs.ini
+++ b/conf/community-rfc-configs.ini
@@ -18,7 +18,7 @@
 ##############################################################################
 
 Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.Telemetry.Version="2.0"
-Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.Telemetry.ConfigURL=https://xconf.rdkcentral.com:19092/loguploader/getT2Settings
+Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.Telemetry.ConfigURL=https://xconf.rdkcentral.com/loguploader/getT2Settings
 Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.AccountInfo.AccountID="1234"
 Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.Telemetry.MTLS.Enable=false
 Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.AppHibernate.Enable=true

--- a/recipes-images/rdk-fullstack-image.bb
+++ b/recipes-images/rdk-fullstack-image.bb
@@ -12,9 +12,12 @@ IMAGE_INSTALL = " \
 # VOLATILE_BINDS configuration can change for each layer, it has to be built locally across all layer
 IMAGE_INSTALL:append = " volatile-binds"
 
-inherit core-image
+inherit core-image custom-rootfs-creation extrausers
 
-inherit custom-rootfs-creation
+EXTRA_USERS_PARAMS:append = "${@bb.utils.contains('DISTRO_FEATURES', 'amazon_non_root_support', '''\
+    groupadd -g 1000 amazon;\
+    useradd -u 1000 -g amazon -M -r -s /bin/sh amazon;\
+''', '', d)}"
 
 IMAGE_ROOTFS_SIZE ?= "8192"
 IMAGE_ROOTFS_EXTRA_SPACE:append = "${@bb.utils.contains("DISTRO_FEATURES", "systemd", " + 4096", "" ,d)}"


### PR DESCRIPTION
Reason for Change: Enable creation of `amazon` user with the help of `extrausers` bbclass for products enabled with `amazon_non_root_support` DISTRO_FEATURE for app certification requirement.