### PR TITLE
PREMIUMAPP-3420: [Amazon non-root user] Update group ID to 1001

### DIFF
--- a/recipes-images/rdk-fullstack-image.bb
+++ b/recipes-images/rdk-fullstack-image.bb
@@ -15,8 +15,8 @@ IMAGE_INSTALL:append = " volatile-binds"
 inherit core-image custom-rootfs-creation extrausers
 
 EXTRA_USERS_PARAMS:append = "${@bb.utils.contains('DISTRO_FEATURES', 'amazon_non_root_support', '''\
-    groupadd -g 1000 amazon;\
-    useradd -u 1000 -g amazon -M -r -s /bin/sh amazon;\
+    groupadd -g 1001 amazon;\
+    useradd -u 1001 -g amazon -M -r -s /bin/sh amazon;\
 ''', '', d)}"
 
 IMAGE_ROOTFS_SIZE ?= "8192"


### PR DESCRIPTION
Reason for change: Currently the group id for amazon is added as 1000. This group add command does not succeed in Realtek since group id 1000 is already used in RTK "vpu" group.

Test Procedure: Build and verify.

Risks: Low