### PR TITLE
RDKEVL-7365:[RPI] OSS and common metalayers update

### DIFF
--- a/conf/template/bblayers.conf.sample
+++ b/conf/template/bblayers.conf.sample
@@ -24,7 +24,6 @@ BBLAYERS =+ "${@'${MANIFEST_PATH_RDK_AUXILIARY}' if os.path.isfile('${MANIFEST_P
 
 # All required release layers
 BBLAYERS =+ "${@'${MANIFEST_PATH_COMMON_OSS_REFERENCE}' if os.path.isfile('${MANIFEST_PATH_COMMON_OSS_REFERENCE}/conf/layer.conf') else ''}"
-BBLAYERS =+ "${@'${MANIFEST_PATH_OSS_RELEASE}' if os.path.isfile('${MANIFEST_PATH_OSS_RELEASE}/conf/layer.conf') else ''}"
 BBLAYERS =+ "${@'${MANIFEST_PATH_VENDOR_RELEASE}' if os.path.isfile('${MANIFEST_PATH_VENDOR_RELEASE}/conf/layer.conf') else ''}"
 BBLAYERS =+ "${@'${MANIFEST_PATH_APPLICATION_RELEASE}' if os.path.isfile('${MANIFEST_PATH_APPLICATION_RELEASE}/conf/layer.conf') else ''}"
 BBLAYERS =+ "${@'${MANIFEST_PATH_MW_RELEASE}' if os.path.isfile('${MANIFEST_PATH_MW_RELEASE}/conf/layer.conf') else ''}"


### PR DESCRIPTION
Reason: Removed MANIFEST_PATH_OSS_RELEASE/meta-oss-reference-release in bblayers as part of new OSS arch.